### PR TITLE
Add compatibility with NVDA2023.1 and prepare to publish on the store

### DIFF
--- a/addon/globalPlugins/sayKeyboardLanguage.py
+++ b/addon/globalPlugins/sayKeyboardLanguage.py
@@ -1,8 +1,8 @@
 # -*- coding: UTF-8 -*-
 # sayKeyboardLanguage.py
 # Copyright 2017-2018 Abdelkrim Bensaïd, Noelia Ruiz-Martinez and other contributors, released under gPL.
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 # Authors:
 # Abdel <abdelkrim.bensaid@gmail.com>
 # Noelia <nrm1977@gmail.com>

--- a/buildVars.py
+++ b/buildVars.py
@@ -25,7 +25,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""This addon provides a command to know the language of the keyboard in use, as well as the default language of the system."""),
 	# version
-	"addon_version" : "22.06",
+	"addon_version" : "20230425.0.0",
 	# Author(s)
 	"addon_author" : u"Abdel <abdelkrim.bensaid@gmail.com>, Noelia <nrm1977@gmail.com>",
 	# URL for the add-on documentation support
@@ -33,9 +33,9 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion" : "2014.3",
+	"addon_minimumNVDAVersion" : "0.0.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2022.1",
+	"addon_lastTestedNVDAVersion" : "2023.1.0",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,11 @@ You will then find the script in the "System status" category.
 
 * This add-on is compatible with the versions of NVDA ranging from 2014.3 and beyond.
 
+## Changes for version 20230425.0.0 ##
+
+* Changed version number, minimum NVDA version and download link according to store conventions/requirements.
+* Compatible with NVDA2023.1 and beyond.
+
 ## Changes for version 19.02 ##
 
 * Changed version numbering using YY.MM (The year in 2 digits, followed by a dot, followed by the month in 2 digits);
@@ -40,6 +45,6 @@ You will then find the script in the "System status" category.
 
 * Initial version.
 
-[1]: https://addons.nvda-project.org/files/get.php?file=ckbl
+[1]: https://www.nvaccess.org/addonStore/legacy?file=sayCurrentKeyboardLanguage
 
 [2]: https://addons.nvda-project.org/files/get.php?file=ckbl-dev


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
This add-on needs to be updated for compatibility with NVDA 2023.1.
It has been mentioned in this [topic posted on the add-onsmailing list](https://nvda-addons.groups.io/g/nvda-addons/topic/98193582)

### Description of how this pull request fixes the issue:
Changed buildVars and minor changes for linting.
### Testing performed:
None yet, checked source code.
### Known issues with pull request:
None
### Change log entry:
* Changed version number, minimum NVDA version and download link according to store conventions/requirements.
* Compatible with NVDA2023.1 and beyond.